### PR TITLE
Additional flexibility in header_regex, add tests

### DIFF
--- a/src/readdata.jl
+++ b/src/readdata.jl
@@ -12,9 +12,11 @@ The function automatically tries to parse the species names and the Uniprot ID, 
 a standard format specification. The species names are then used in the matching procedure;
 the Uniprot IDs are only used for writing the output files.
 
-You can parse arbitrary files by providing a custom `header_regex`, which needs to have
-exactly two capture groups, the first one returning the Uniprot ID and the second the
-species name. For example, if the headers in your FASTA file look like this:
+You can parse arbitrary files by providing a custom `header_regex` (see also the
+[Julia regex documentation](http://docs.julialang.org/en/stable/manual/strings/#regular-expressions)).
+In its simples form, it needs to have at least two capture groups, the first one returning the
+Uniprot ID and the second the species name (additional capture groups are ignored).
+For example, if the headers in your FASTA file look like this:
 
 ```text
 >SOMELOCATION/SOMESPECIES/OTHERINFO
@@ -22,7 +24,18 @@ species name. For example, if the headers in your FASTA file look like this:
 
 then you can use a regex like this one: `read_fasta_alignment(..., header_regex=r"^([^/]+)/([^/]+)/")`,
 i.e. line start, anything except a slash (captured), followed by a slash, then anything except a slash
-(captured), then a slash — the remainder of the line is then simply ignored.
+(captured), then a slash — the remainder of the line is then simply ignored. In more complicated cases
+(e.g. if the UniprotID and the species name are out of order), you can use named capture groups: in this
+case the `header_regex` needs to contain both an `id` group and a `species` group (all additional groups are
+ignored). For example, if the headers in your FASTA file look like this:
+
+```text
+>SOMESPECIES/OTHERINFO/SOMELOCATION
+```
+
+then you can use a regex like this one: `header_regex=r"^(?<species>[^/]+)/([^/]+)/(?<id>.+)"`,
+i.e. line start, anything except a slash (capture as the species name), followed by a slash, then anything
+except a slash (captured but ignored), followed by a slash, then the rest of the line (captured as the ID).
 """
 function read_fasta_alignment(filename::AbstractString, max_gap_fraction::Float64 = 1.0; header_regex::Union{Void,Regex} = nothing)
     f = FastaReader(filename)
@@ -63,7 +76,7 @@ function read_fasta_alignment(filename::AbstractString, max_gap_fraction::Float6
         ngaps / fseqlen <= max_gap_fraction && push!(seqs, f.num_parsed)
     end
 
-    length(seqs) > 0 || error("Out of $(f.num_parsed) sequences, none passed the filter (max_gap_fraction=$max_gap_fraction)")
+    length(seqs) > 0 || error("out of $(f.num_parsed) sequences, none passed the filter (max_gap_fraction=$max_gap_fraction)")
 
     # pass 2
 
@@ -91,13 +104,16 @@ function read_fasta_alignment(filename::AbstractString, max_gap_fraction::Float6
     return Alignment(size(Z, 1), size(Z, 2), Int(maximum(Z)), Z', sequence, header, spec_name, spec_id, uniprot_id)
 end
 
-function specname(s::String, header_regex::Union{Void,Regex} = nothing)
+function specname(s::String, header_regex::Union{Void,Regex}, captureinds::NTuple{2,Integer})
     if header_regex ≢ nothing
         # user-defined format
         if ismatch(header_regex, s)
             captures = match(header_regex, s).captures
-            length(captures) == 2 || error("Invalid header regex: should always return 2 captured groups if it matches; has returned: $(length(captures))")
-            uniprot_id, spec_name = captures
+            length(captures) ≥ 2 ||
+                error("invalid header regex: should always return at least 2 captured groups if it matches; has returned: $(length(captures))")
+            uniprot_id, spec_name = captures[captureinds[1]], captures[captureinds[2]]
+            isa(uniprot_id, AbstractString) || error("the capture group for `id` did not match the spec string: $s")
+            isa(spec_name, AbstractString) || error("the capture group for `species` did not match the spec string: $s")
         else
             error("unrecognized spec string: $s")
         end
@@ -131,8 +147,23 @@ function compute_spec(header::Vector{String}, header_regex::Union{Void,Regex} = 
     spec_name = Array{String}(M)
     uniprot_id  = Array{String}(M)
 
+    captureinds = (1,2)
+    if header_regex ≢ nothing
+        cnamesdict = Base.PCRE.capture_names(header_regex.regex)
+        cnames = collect(values(cnamesdict))
+        if "id" ∈ cnames && "species" ∈ cnames
+            ckeys = collect(keys(cnamesdict))
+            captureinds = (ckeys[findfirst(i->cnamesdict[i]=="id", ckeys)],
+                           ckeys[findfirst(i->cnamesdict[i]=="species", ckeys)])
+        elseif "id" ∉ cnames && "species" ∉ cnames
+            nothing
+        else
+            error("only one of `id` and `species` capture names found in `header_regex`; either none or both should be used")
+        end
+    end
+
     for i = 1:M
-        uniprot_id[i], spec_name[i] = specname(header[i], header_regex)
+        uniprot_id[i], spec_name[i] = specname(header[i], header_regex, captureinds)
     end
 
     specunique = unique(spec_name)


### PR DESCRIPTION
Allows named capture groups in FASTA header files parsing, and add tests.
Also a small unrelated fix in the tests.