### PR TITLE
Update for julia 0.6, drop 0.4 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,8 +4,8 @@ os:
   - linux
   - osx
 julia:
-  - 0.4
   - 0.5
+  - 0.6
   - nightly
 notifications:
   email: false
@@ -14,7 +14,7 @@ addons:
   - libgmp-dev
 script:
   - if [[ -a .git/shallow ]]; then git fetch --unshallow; fi
-  - julia --inline=no -e 'Pkg.clone(pwd()); Pkg.build("ParalogMatching"); Pkg.add("GLPKMathProgInterface"); Pkg.test("ParalogMatching"; coverage=true)'
+  - julia --inline=no -e 'Pkg.clone(pwd()); Pkg.build("ParalogMatching"); Pkg.test("ParalogMatching"; coverage=true)'
 after_success:
   - julia -e 'Pkg.add("Documenter", v"0.1.4")'
   - julia -e 'cd(Pkg.dir("ParalogMatching")); include(joinpath("docs", "make.jl"))'

--- a/README.md
+++ b/README.md
@@ -8,24 +8,24 @@ This package implements the paralog matching technique presented in the paper
 *"Simultaneous identification of specifically interacting paralogs and
 interprotein contacts by Direct Coupling Analysis"*
 by Thomas Gueudré, Carlo Baldassi, Marco Zamparo, Martin Weigt and Andrea Pagnani,
-Proc. Natl. Acad. Sci. U.S.A. 113, 12186–12191 (2016), [doi:10.1073/pnas.1607570113](http://dx.doi.org/10.1073/pnas.1607570113)
+Proc. Natl. Acad. Sci. U.S.A. 113, 12186–12191 (2016), [doi:10.1073/pnas.1607570113][paper].
 
 The main idea of the method is to perform a statistical analysis of two given
 multiple sequence alignments, each containing one protein family. Each familiy should
 comprise several species, and each species may have several sequences belonging to the
 family. The algorithm tries to associate (match) interacting partners from the two families
 within each species. It belongs to the more general class of
-[Direct Coupling Analysis methods](https://en.wikipedia.org/wiki/Direct_coupling_analysis). 
+[Direct Coupling Analysis methods][dca-wiki].
 
 The underlying main assumption is that the proper matching is the one maximizing the
 co-evolution signal. Such maximization is performed over the Bayesian inference of a
 Gaussian model, by inverting the correlation matrix.
 
-The code is written in [Julia](http://julialang.org), and the functions are called
+The code is written in [Julia][julia], and the functions are called
 from within Julia. However, a command-line interface is also provided for
 those unfamiliar with the language (see the documentation).
 
-The package is tested against Julia `0.4`, `0.5` and *current* `0.6-dev` on Linux, OS X, and Windows.
+The package is tested against Julia `0.5` and *current* `0.6-pre` on Linux, OS X, and Windows.
 
 ## Installation
 
@@ -37,12 +37,13 @@ julia> Pkg.clone("https://github.com/Mirmu/ParalogMatching.jl")
 
 Dependencies will be installed automatically.
 
-However, you will also need to install at least one linear programming solver supported by
-[MathProgBase](http://mathprogbasejl.readthedocs.io/en/latest/).
-See the list of available solvers at the [JuliaOpt page](http://www.juliaopt.org/#packages).
-Note that the solver efficiency is not particularly important for paralog matching, whose computational time
-is dominated by matrix inversion operations, therefore you don't need a particularly fast solver. If unsure,
-use `Pkg.add("Clp")` or `Pkg.add("GLPKMathProgInterface")`, which are free and open-source solvers.
+The package requires to install at least one linear programming solver supported by
+[MathProgBase][mathprogbase].
+By default, it uses [GLPK][glpk], which is free and open source, but you can choose any another:
+see the list of available solvers at the [JuliaOpt page][solvers].
+However, note that the solver efficiency is not particularly important for paralog matching,
+whose computational time is dominated by matrix inversion operations, therefore it's likely that
+you won't need a particularly fast solver.
 
 ## Documentation
 
@@ -52,6 +53,14 @@ use `Pkg.add("Clp")` or `Pkg.add("GLPKMathProgInterface")`, which are free and o
 
 Contributions are very welcome, as are feature requests and suggestions. Please open an
 [issue][issues-url] if you encounter any problems or would just like to ask a question.
+
+[paper]: http://dx.doi.org/10.1073/pnas.1607570113
+[dca-wiki]: https://en.wikipedia.org/wiki/Direct_coupling_analysis
+[julia]: https://julialang.org
+
+[mathprogbase]: http://mathprogbasejl.readthedocs.io/en/latest/
+[glpk]: https://github.com/JuliaOpt/GLPK.jl
+[solvers]: http://www.juliaopt.org/#packages
 
 [docs-latest-img]: https://img.shields.io/badge/docs-latest-blue.svg
 [docs-latest-url]: https://Mirmu.github.io/ParalogMatching.jl/latest

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,8 +1,8 @@
-julia 0.4
+julia 0.5
 FastaIO
 Iterators
-Compat 0.8
 Distributions
-MathProgBase 0.5.0 0.6-
+MathProgBase 0.6.0 0.7-
 ExtractMacro
 ArgParse
+GLPKMathProgInterface 0.3.0

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,9 +1,9 @@
 environment:
   matrix:
-  - JULIAVERSION: "julialang/bin/winnt/x86/0.4/julia-0.4-latest-win32.exe"
-  - JULIAVERSION: "julialang/bin/winnt/x64/0.4/julia-0.4-latest-win64.exe"
   - JULIAVERSION: "julialang/bin/winnt/x86/0.5/julia-0.5-latest-win32.exe"
   - JULIAVERSION: "julialang/bin/winnt/x64/0.5/julia-0.5-latest-win64.exe"
+  - JULIAVERSION: "julialang/bin/winnt/x86/0.6/julia-0.6-latest-win32.exe"
+  - JULIAVERSION: "julialang/bin/winnt/x64/0.6/julia-0.6-latest-win64.exe"
   - JULIAVERSION: "julianightlies/bin/winnt/x86/julia-latest-win32.exe"
   - JULIAVERSION: "julianightlies/bin/winnt/x64/julia-latest-win64.exe"
 
@@ -30,7 +30,7 @@ build_script:
 # Need to convert from shallow to complete for Pkg.clone to work
   - IF EXIST .git\shallow (git fetch --unshallow)
   - C:\projects\julia\bin\julia -e "versioninfo();
-      Pkg.clone(pwd(), \"ParalogMatching\"); Pkg.build(\"ParalogMatching\"); Pkg.add(\"GLPKMathProgInterface\")"
+      Pkg.clone(pwd(), \"ParalogMatching\"); Pkg.build(\"ParalogMatching\")"
 
 test_script:
   - C:\projects\julia\bin\julia --check-bounds=yes -e "Pkg.test(\"ParalogMatching\")"

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -34,12 +34,14 @@ julia> Pkg.clone("https://github.com/Mirmu/ParalogMatching.jl")
 
 Dependencies will be installed automatically.
 
-However, you will also need to install at least one linear programming solver supported by
+The package requires to install at least one linear programming solver supported by
 [MathProgBase](http://mathprogbasejl.readthedocs.io/en/latest/).
-See the list of available solvers at the [JuliaOpt page](http://www.juliaopt.org/#packages).
-Note that the solver efficiency is not particularly important for paralog matching, whose computational time
-is dominated by matrix inversion operations, therefore you don't need a particularly fast solver. If unsure,
-use `Pkg.add("Clp")` or `Pkg.add("GLPKMathProgInterface")`, which are free and open-source solvers.
+By default, it uses [GLPK](https://github.com/JuliaOpt/GLPK.jl), which is free and open source,
+but you can choose any another: see the list of available solvers at the
+[JuliaOpt page](http://www.juliaopt.org/#packages).
+However, note that the solver efficiency is not particularly important for paralog matching,
+whose computational time is dominated by matrix inversion operations, therefore it's likely that
+you won't need a particularly fast solver.
 
 ### Usage
 

--- a/src/ParalogMatching.jl
+++ b/src/ParalogMatching.jl
@@ -2,14 +2,14 @@
 
 module ParalogMatching
 
-using FastaIO, ExtractMacro, Iterators, Compat
+using FastaIO, ExtractMacro, Iterators
 using Distributions
 using MathProgBase
+using GLPKMathProgInterface
+const default_lpsolver = GLPKSolverLP()
 
 export read_fasta_alignment, prepare_alignments, run_matching,
        write_fasta_match, paralog_matching
-
-import Compat: String
 
 # Including the types used for the Matching
 include("types.jl")

--- a/src/manip_fasta.jl
+++ b/src/manip_fasta.jl
@@ -29,11 +29,7 @@ function harmonize_fasta(X1::Alignment, X2::Alignment)
 
     isempty(kept) && error("No species in common found in the alignments")
 
-    #@compat kd = Dict(s=>i for (i,s) in enumerate(kept)) # associate an index to each kept species
-    kd = Dict{String,Int}() # TODO: use generators when 0.4 support is dropped
-    for (i,s) in enumerate(kept)
-	kd[s] = i
-    end
+    kd = Dict(s=>i for (i,s) in enumerate(kept)) # associate an index to each kept species
 
     ind1, sid1 = compute_new_inds(spec_name1, kd)
     ind2, sid2 = compute_new_inds(spec_name2, kd)

--- a/src/manip_fasta.jl
+++ b/src/manip_fasta.jl
@@ -9,12 +9,12 @@ function order_and_cut(Xtot::Alignment, cutoff::Integer)
     kept = Int[]
     # Orders so that families have contiguous sequences organized in blocks
     for (fam,n,inds) in cand
-	n > cutoff && continue
-	append!(kept, inds)
+        n > cutoff && continue
+        append!(kept, inds)
     end
 
     return Alignment(N, length(kept), q, Z[kept,:],
-		     sequence[kept], header[kept], spec_name[kept], spec_id[kept], uniprot_id[kept])
+                     sequence[kept], header[kept], spec_name[kept], spec_id[kept], uniprot_id[kept])
 end
 
 # Harmonizing consists of creating the following structure for a FASTA:
@@ -35,9 +35,9 @@ function harmonize_fasta(X1::Alignment, X2::Alignment)
     ind2, sid2 = compute_new_inds(spec_name2, kd)
 
     al1 = Alignment(N1, length(ind1), q1, Z1[ind1, :], sequence1[ind1], header1[ind1],
-		    spec_name1[ind1], sid1, uniprot_id1[ind1])
+                    spec_name1[ind1], sid1, uniprot_id1[ind1])
     al2 = Alignment(N2, length(ind2), q2, Z2[ind2, :], sequence2[ind2], header2[ind2],
-		    spec_name2[ind2], sid2, uniprot_id2[ind2])
+                    spec_name2[ind2], sid2, uniprot_id2[ind2])
 
     return HarmonizedAlignments(al1, al2)
 end
@@ -47,10 +47,10 @@ function compute_new_inds(spec_name::Vector{String}, kd::Dict{String,Int})
     ind = Int[] # the subset of indices to keep
     sid = Int[] # the new species ids
     for (i,s) in enumerate(spec_name)
-	id = get(kd, s, 0) # get the species index in the `kept` vector
-	id == 0 && continue # the species is not in `kept`
-	push!(sid, id)
-	push!(ind, i)
+        id = get(kd, s, 0) # get the species index in the `kept` vector
+        id == 0 && continue # the species is not in `kept`
+        push!(sid, id)
+        push!(ind, i)
     end
     # here, ind is sorted but sid is not
     # we want to sort everything according to the new species ids
@@ -66,9 +66,9 @@ end
 function write_fasta(X1::Alignment, name::AbstractString)
     @extract X1 : header sequence
     FastaWriter(name) do f
-	for (h,s) in zip(header, sequence)
-	    writeentry(f, h, s)
-	end
+        for (h,s) in zip(header, sequence)
+            writeentry(f, h, s)
+        end
     end
 end
 
@@ -87,14 +87,14 @@ The new sequences in the output file are the concatenation of the matched sequen
 function write_fasta_match(X12::HarmonizedAlignments, match::Vector{Int}, outfile::AbstractString)
     @extract X12 : X1 X2
     FastaWriter(outfile) do f
-	for (i,edge) in enumerate(match)
-	    edge == 0 && continue
-	    X1.spec_name[i] == X2.spec_name[edge] || error("do you have a well formed match ?")
-	    h = string(">", X1.uniprot_id[i], "::", X2.uniprot_id[edge], "/", X1.spec_name[i])
-	    write(f, h)
-	    write(f, X1.sequence[i])
-	    write(f, X2.sequence[edge])
-	end
+        for (i,edge) in enumerate(match)
+            edge == 0 && continue
+            X1.spec_name[i] == X2.spec_name[edge] || error("do you have a well formed match ?")
+            h = string(">", X1.uniprot_id[i], "::", X2.uniprot_id[edge], "/", X1.spec_name[i])
+            write(f, h)
+            write(f, X1.sequence[i])
+            write(f, X2.sequence[edge])
+        end
     end
 end
 
@@ -109,16 +109,16 @@ function intersection_fasta(name1::AbstractString, name2::AbstractString; printt
     M2 = X2.M
     isize = 0
     if printtofile
-	f = FastaWriter(string("INTERSECTION_", name1, "-", name2, ".fasta.gz"))
+        f = FastaWriter(string("INTERSECTION_", name1, "-", name2, ".fasta.gz"))
     end
     try
-	for (h,s) in zip(X1.header, X1.sequence)
-	    h ∈ X2.header || continue
-	    printtofile && writeentry(f, h, s)
-	    isize += 1
-	end
+        for (h,s) in zip(X1.header, X1.sequence)
+            h ∈ X2.header || continue
+            printtofile && writeentry(f, h, s)
+            isize += 1
+        end
     finally
-	printtofile && close(f)
+        printtofile && close(f)
     end
     return isize, M1, M2
 end
@@ -132,19 +132,19 @@ function union_fasta(name1::AbstractString, name2::AbstractString; printtofile::
     M2 = X2.M
     usize = M1
     if printtofile
-	f = FastaWriter(string("UNION_", name1, "-", name2, ".fasta.gz"))
-	for (h,s) in zip(X1.header, X1.sequence)
-	    writeentry(f, h, s)
-	end
+        f = FastaWriter(string("UNION_", name1, "-", name2, ".fasta.gz"))
+        for (h,s) in zip(X1.header, X1.sequence)
+            writeentry(f, h, s)
+        end
     end
     try
-	for (h,s) in zip(X2.header, X2.sequence)
-	    h ∈ X1.header && continue
-	    printtofile && writeentry(f, h, s)
-	    usize += 1
-	end
+        for (h,s) in zip(X2.header, X2.sequence)
+            h ∈ X1.header && continue
+            printtofile && writeentry(f, h, s)
+            usize += 1
+        end
     finally
-	printtofile && close(f)
+        printtofile && close(f)
     end
     return usize, M1, M2
 end

--- a/src/matching_fasta.jl
+++ b/src/matching_fasta.jl
@@ -17,8 +17,8 @@ filter entirely.
 function prepare_alignments(Xi1::Alignment, Xi2::Alignment; cutoff::Integer = 500)
     cutoff == 0 && (cutoff = typemax(Int))
     println("initializing the matching",
-	    cutoff < typemax(Int) ? ", removing families larger than $cutoff" : "",
-	    "...")
+            cutoff < typemax(Int) ? ", removing families larger than $cutoff" : "",
+            "...")
     return harmonize_fasta(order_and_cut(Xi1, cutoff), order_and_cut(Xi2, cutoff))
 end
 
@@ -37,9 +37,9 @@ function start_matching(X12::HarmonizedAlignments)
     candi = intersect(spec_id1[ind1], spec_id2[ind2])
 
     for el in candi
-	a1 = findfirst(spec_id1, el)
-	a2 = findfirst(spec_id2, el)
-	match[a1] = a2
+        a1 = findfirst(spec_id1, el)
+        a2 = findfirst(spec_id2, el)
+        match[a1] = a2
     end
     return match
 end
@@ -73,8 +73,8 @@ end
 # par_corr gathers for each species in specl, the matching obtained by the "strategy" strategy
 # And returns an array of those matchings
 function par_corr(X1::Alignment, X2::Alignment, freq::FreqC, invC::Matrix{Float64},
-		  specl::Vector{Int}, strategy::AbstractString,
-		  lpsolver::MathProgBase.SolverInterface.AbstractMathProgSolver)
+                  specl::Vector{Int}, strategy::AbstractString,
+                  lpsolver::MathProgBase.SolverInterface.AbstractMathProgSolver)
     return [give_correction(X1, X2, freq, invC, i, strategy, lpsolver) for i in specl]
 end
 
@@ -90,13 +90,13 @@ function spec_entropy(X1::Alignment, X2::Alignment)
     entropy = Tuple{Int,Float64}[]
 
     for i in 1:length(bib1)
-	bib1[i][1] == bib2[i][1] || error("non harmonized fasta")
+        bib1[i][1] == bib2[i][1] || error("non harmonized fasta")
 
-	mini = min(bib1[i][2], bib2[i][2])
-	maxi = max(bib1[i][2], bib2[i][2])
+        mini = min(bib1[i][2], bib2[i][2])
+        maxi = max(bib1[i][2], bib2[i][2])
 
-	ent = sum([log(i) for i in (maxi-mini+1):maxi])
-	push!(entropy, (bib1[i][1], ent))
+        ent = sum([log(i) for i in (maxi-mini+1):maxi])
+        push!(entropy, (bib1[i][1], ent))
     end
     return [a[1] for a in filter(x->x[2]!=0, sort(entropy, by=x->x[2]))]
 end
@@ -111,17 +111,17 @@ function apply_matching!(X1, X2, match, lspec, lmatch)
     length(lspec) == length(lmatch) || error("data non compatible")
 
     for (i,el) in enumerate(lspec)
-	ind1 = find(spec_id1 .== el)
-	ind2 = find(spec_id2 .== el)
-	match[ind1[lmatch[i][1]]] = ind2[lmatch[i][2]]
+        ind1 = find(spec_id1 .== el)
+        ind2 = find(spec_id2 .== el)
+        match[ind1[lmatch[i][1]]] = ind2[lmatch[i][2]]
     end
     return nothing
 end
 
 """
     run_matching(X12::HarmonizedAlignments;
-		 batch = 1,
-		 strategy = "covariation",
+                 batch = 1,
+                 strategy = "covariation",
                  lpsolver = GLPKSolverLP())
 
 Returns the matching of the two alignments contained in `X12`, which need to be obtained by [`prepare_alignments`](@ref).
@@ -139,9 +139,9 @@ The keywords are:
                   A defaut of 0.5 gives sensible results, its value cannot be above 1.0.
 
 * `lpsolver`: linear programming solver used when performing the matching with the `"covariation"` strategy.
-	      The default uses a solver provided bu the `GLPK` library.
-	      You can override this by passing e.g. `lpsolver = GurobiSolver(OutputFlag=false)` or similar
-	      (see the documentation for `MathProgBase`).
+              The default uses a solver provided bu the `GLPK` library.
+              You can override this by passing e.g. `lpsolver = GurobiSolver(OutputFlag=false)` or similar
+              (see the documentation for `MathProgBase`).
 
 Available strategies are:
 
@@ -152,20 +152,20 @@ Available strategies are:
 + `"random"`: produces a random matching, only useful to produce null models.
 
 + `"genetic"`: tries to use the Uniprot ID information to determine which sequences belong to the
-	       same operon (only used for testing, not a valid general strategy)
+               same operon (only used for testing, not a valid general strategy)
 
 """
 function run_matching(X12::HarmonizedAlignments;
-		      batch::Integer = 1,
-		      pseudo_count::Float64 = 0.5,
-		      strategy::AbstractString = "covariation",
-		      lpsolver::MathProgBase.SolverInterface.AbstractMathProgSolver = default_lpsolver)
+                      batch::Integer = 1,
+                      pseudo_count::Float64 = 0.5,
+                      strategy::AbstractString = "covariation",
+                      lpsolver::MathProgBase.SolverInterface.AbstractMathProgSolver = default_lpsolver)
 
     X1, X2, match, freq, corr, invC = initialize_matching(X12, pseudo_count)
 
     valid_strats = ["covariation", "genetic", "random", "greedy"]
     strategy ∈ valid_strats ||
-	throw(ArgumentError("unknown strategy: $strategy. Must be one of: $(join(valid_strats, ", ", " or "))"))
+        throw(ArgumentError("unknown strategy: $strategy. Must be one of: $(join(valid_strats, ", ", " or "))"))
     pseudo_count>0.0 && (pseudo_count < 1.0) || throw(ArgumentError("invalid value of the pseudo_count, must be a real between 0.0 and 1.0"))
 
     # Computes the entropy of the families and batch them from easiest to hardest
@@ -175,23 +175,23 @@ function run_matching(X12::HarmonizedAlignments;
 
     # For each batch...
     for el in batchl
-	isempty(el) && continue
+        isempty(el) && continue
 
-	# Performs the matching for each species of the batch
-	res = par_corr(X1, X2, freq, invC, el, strategy, lpsolver)
-	println("batch of species")
-	println(el)
-	println(res)
+        # Performs the matching for each species of the batch
+        res = par_corr(X1, X2, freq, invC, el, strategy, lpsolver)
+        println("batch of species")
+        println(el)
+        println(res)
 
-	# Applies the matching to the global matching vector
-	apply_matching!(X1, X2, match, el, res)
+        # Applies the matching to the global matching vector
+        apply_matching!(X1, X2, match, el, res)
 
-	if strategy == "covariation" || strategy == "greedy"
-	    println("Recomputing the model")
-	    # Updates the freq and corr matrices, and its inverse
-	    unitFC!(X1, X2, match, el, freq)
-	    invC = inverse_with_pseudo!(corr, freq, pseudo_count)
-	end
+        if strategy == "covariation" || strategy == "greedy"
+            println("Recomputing the model")
+            # Updates the freq and corr matrices, and its inverse
+            unitFC!(X1, X2, match, el, freq)
+            invC = inverse_with_pseudo!(corr, freq, pseudo_count)
+        end
 
     end
     clear_inverse_mem()
@@ -201,9 +201,9 @@ end
 
 """
     paralog_matching(infile1::AbstractString, infile2::AbstractString, outfile::AbstractString;
-		     cutoff = 500,
-		     batch = 1,
-		     strategy = "covariation",
+                     cutoff = 500,
+                     batch = 1,
+                     strategy = "covariation",
                      lpsolver = GLPKSolverLP())
 
 This function performs the paralog matching from two given FASTA files containing the alignments for
@@ -220,13 +220,13 @@ Besides writing the `outfile`, this function also returns two values: the harmon
 by [`prepare_alignments`](@ref)) and the resulting match (as returned by [`run_matching`](@ref)).
 """
 function paralog_matching(infile1::AbstractString,
-			  infile2::AbstractString,
-			  outfile::AbstractString;
-			  cutoff::Integer = 500,
-			  batch::Integer = 1,
-			  strategy::AbstractString = "covariation",
-			  pseudo_count::Float64= 0.5,
-			  lpsolver::MathProgBase.SolverInterface.AbstractMathProgSolver = default_lpsolver)
+                          infile2::AbstractString,
+                          outfile::AbstractString;
+                          cutoff::Integer = 500,
+                          batch::Integer = 1,
+                          strategy::AbstractString = "covariation",
+                          pseudo_count::Float64= 0.5,
+                          lpsolver::MathProgBase.SolverInterface.AbstractMathProgSolver = default_lpsolver)
 
     X1 = read_fasta_alignment(infile1)
     X2 = read_fasta_alignment(infile2)

--- a/src/matching_fasta.jl
+++ b/src/matching_fasta.jl
@@ -122,7 +122,7 @@ end
     run_matching(X12::HarmonizedAlignments;
 		 batch = 1,
 		 strategy = "covariation",
-		 lpsolver = nothing)
+                 lpsolver = GLPKSolverLP())
 
 Returns the matching of the two alignments contained in `X12`, which need to be obtained by [`prepare_alignments`](@ref).
 The returned matching is a Vector in which the entry `i` determines which sequence of the second alignment
@@ -139,7 +139,7 @@ The keywords are:
                   A defaut of 0.5 gives sensible results, its value cannot be above 1.0.
 
 * `lpsolver`: linear programming solver used when performing the matching with the `"covariation"` strategy.
-	      The default (`nothing`) uses the default solver as detected automatically by `MathProgBase`.
+	      The default uses a solver provided bu the `GLPK` library.
 	      You can override this by passing e.g. `lpsolver = GurobiSolver(OutputFlag=false)` or similar
 	      (see the documentation for `MathProgBase`).
 
@@ -159,7 +159,7 @@ function run_matching(X12::HarmonizedAlignments;
 		      batch::Integer = 1,
 		      pseudo_count::Float64 = 0.5,
 		      strategy::AbstractString = "covariation",
-		      lpsolver::Union{MathProgBase.SolverInterface.AbstractMathProgSolver,Void} = nothing)
+		      lpsolver::MathProgBase.SolverInterface.AbstractMathProgSolver = default_lpsolver)
 
     X1, X2, match, freq, corr, invC = initialize_matching(X12, pseudo_count)
 
@@ -167,8 +167,6 @@ function run_matching(X12::HarmonizedAlignments;
     strategy ∈ valid_strats ||
 	throw(ArgumentError("unknown strategy: $strategy. Must be one of: $(join(valid_strats, ", ", " or "))"))
     pseudo_count>0.0 && (pseudo_count < 1.0) || throw(ArgumentError("invalid value of the pseudo_count, must be a real between 0.0 and 1.0"))
-
-    lpsolver ≡ nothing && (lpsolver = MathProgBase.defaultLPsolver)
 
     # Computes the entropy of the families and batch them from easiest to hardest
     spec = spec_entropy(X1, X2)
@@ -206,7 +204,7 @@ end
 		     cutoff = 500,
 		     batch = 1,
 		     strategy = "covariation",
-		     lpsolver = nothing)
+                     lpsolver = GLPKSolverLP())
 
 This function performs the paralog matching from two given FASTA files containing the alignments for
 two different protein families. When the matching is done, it writes the result in a new FASTA file,
@@ -228,7 +226,7 @@ function paralog_matching(infile1::AbstractString,
 			  batch::Integer = 1,
 			  strategy::AbstractString = "covariation",
 			  pseudo_count::Float64= 0.5,
-			  lpsolver::Union{MathProgBase.SolverInterface.AbstractMathProgSolver,Void} = nothing)
+			  lpsolver::MathProgBase.SolverInterface.AbstractMathProgSolver = default_lpsolver)
 
     X1 = read_fasta_alignment(infile1)
     X2 = read_fasta_alignment(infile2)

--- a/src/plotting.jl
+++ b/src/plotting.jl
@@ -21,21 +21,21 @@ function ROC_curve(ndata, plm, split)
 
     for a in 1:size(score)[1]
 
-	# ugliness
-	ind = findfirst(comp, (score[a,1]) + (score[a,2]) * im)
+        # ugliness
+        ind = findfirst(comp, (score[a,1]) + (score[a,2]) * im)
 
-	ind != 0 || continue
+        ind != 0 || continue
 
-	if (((score[a,1] <= split) && (score[a,2] <= split)) || ((score[a,1] > split) && (score[a,2] > split))) && (abs(score[a,1] - score[a,2]) > 4)
-	    data[ind,3] > 8 || (trueintra += 1)
-	    intra += 1
-	    push!(curveintra, trueintra / intra)
+        if (((score[a,1] <= split) && (score[a,2] <= split)) || ((score[a,1] > split) && (score[a,2] > split))) && (abs(score[a,1] - score[a,2]) > 4)
+            data[ind,3] > 8 || (trueintra += 1)
+            intra += 1
+            push!(curveintra, trueintra / intra)
 
-	elseif (score[a,1] <= split) && (score[a,2] > split)
-	    data[ind,3] > 8 || (trueinter += 1)
-	    inter += 1
-	    push!(curveinter, trueinter / inter)
-	end
+        elseif (score[a,1] <= split) && (score[a,2] > split)
+            data[ind,3] > 8 || (trueinter += 1)
+            inter += 1
+            push!(curveinter, trueinter / inter)
+        end
     end
     return curveinter, curveintra
 end
@@ -47,11 +47,11 @@ function curve_true(ordering)
     sorted = sort([ordering...], by=x->x[2])
     rocc = Float64[]
     for el in sorted
-	if el[1][1] == el[1][2]
-	    trueprop += 1
-	end
-	count += 1
-	push!(rocc, trueprop / count)
+        if el[1][1] == el[1][2]
+            trueprop += 1
+        end
+        count += 1
+        push!(rocc, trueprop / count)
     end
     return rocc
 end
@@ -84,15 +84,15 @@ function post_order_scores(X1, X2, match)
     nullconst = 1/2 * (logdet(corr.Cij) - logdet(corr.Cij[1:len1,1:len1]) - logdet(corr.Cij[len1+1:end,len1+1:end]))
 
     for i in 1:lines
-	match[i] != 0 || continue
+        match[i] != 0 || continue
 
-	seq1 = expand_binary(X1.Z[i,:], 20)[:]
-	seq2 = expand_binary(X2.Z[match[i],:], 20)[:]
-	seq = [seq1;seq2]
-	score = -(((seq-aver)[1:len1]') * invC[1:len1,len1+1:end] * ((seq-aver)[len1+1:end]))[1] - nullconst
-	println((i, match[i], score))
+        seq1 = expand_binary(X1.Z[i,:], 20)[:]
+        seq2 = expand_binary(X2.Z[match[i],:], 20)[:]
+        seq = [seq1;seq2]
+        score = -(((seq-aver)[1:len1]') * invC[1:len1,len1+1:end] * ((seq-aver)[len1+1:end]))[1] - nullconst
+        println((i, match[i], score))
 
-	push!(ordering, (i, match[i], score))
+        push!(ordering, (i, match[i], score))
     end
     sort!(ordering, by=x->x[3], rev=true)
     tab = hcat([[a...] for a in ordering]...)'
@@ -127,25 +127,25 @@ function full_edges_scores(X1, X2, match)
 
     println(nullconst)
     for i in 1:lines
-	for j in pairings[i]
-	    seq1 = expand_binary(X1.Z[i,:], 20)[:]
-	    seq2 = expand_binary(X2.Z[j,:], 20)[:]
+        for j in pairings[i]
+            seq1 = expand_binary(X1.Z[i,:], 20)[:]
+            seq2 = expand_binary(X2.Z[j,:], 20)[:]
 
-	    seq = [seq1;seq2]
-	    score = -(((seq-aver)[1:len1]') * invC[1:len1,len1+1:end] * ((seq-aver)[len1+1:end]))[1] - nullconst
-	    println(((i, j), score))
-	    if (X1.spec_id[i] == flag)
-		push!(suborder, ((i, j), score))
-	    end
+            seq = [seq1;seq2]
+            score = -(((seq-aver)[1:len1]') * invC[1:len1,len1+1:end] * ((seq-aver)[len1+1:end]))[1] - nullconst
+            println(((i, j), score))
+            if (X1.spec_id[i] == flag)
+                push!(suborder, ((i, j), score))
+            end
 
-	    if (X1.spec_id[i] != flag) || (i == lines)
-		sort!(suborder, by=x->x[2], rev=true)
-		push!(ordering, suborder)
-		suborder = Tuple{Tuple{Float64,Float64},Float64}[]
-		push!(suborder, ((i, j), score))
-		flag = X1.spec_id[i]
-	    end
-	end
+            if (X1.spec_id[i] != flag) || (i == lines)
+                sort!(suborder, by=x->x[2], rev=true)
+                push!(ordering, suborder)
+                suborder = Tuple{Tuple{Float64,Float64},Float64}[]
+                push!(suborder, ((i, j), score))
+                flag = X1.spec_id[i]
+            end
+        end
     end
     return X1, X2, match, ordering
 end
@@ -153,9 +153,9 @@ end
 function selecting_edges(ordering, thres)
     order2 = Vector{Tuple{Tuple{Float64,Float64},Float64}}[]
     for el in ordering
-	len = length(el)
-	extr = sort(el,by=x->x[2])[1:min(len,thres)]
-	push!(order2, extr)
+        len = length(el)
+        extr = sort(el,by=x->x[2])[1:min(len,thres)]
+        push!(order2, extr)
     end
     return order2
 end
@@ -181,11 +181,11 @@ function compute_score(score, split)
     mean = 0
     l = size(score)[1]
     for i in 1:l
-	if (score[i,1] <= split) && (score[i,2] > split)
-	    counter += 1
-	    mean += score[i, 3]
-	end
-	counter == 4 && break
+        if (score[i,1] <= split) && (score[i,2] > split)
+            counter += 1
+            mean += score[i, 3]
+        end
+        counter == 4 && break
     end
     return mean / 4
 end

--- a/src/readdata.jl
+++ b/src/readdata.jl
@@ -80,9 +80,9 @@ function read_fasta_alignment(filename::AbstractString, max_gap_fraction::Float6
 
     # pass 2
 
-    Z = Array(Int8, fseqlen, length(seqs))
-    header =  Array(String, length(seqs));
-    sequence =  Array(String, length(seqs));
+    Z = Array{Int8}(fseqlen, length(seqs))
+    header =  Array{String}(length(seqs));
+    sequence =  Array{String}(length(seqs));
     seqid = 1
     for (name, seq) in f
         header[seqid] = name
@@ -167,11 +167,7 @@ function compute_spec(header::Vector{String}, header_regex::Union{Void,Regex} = 
     end
 
     specunique = unique(spec_name)
-    #@compat sdict = Dict([s=>i for (i,s) in enumerate(specunique)])
-    sdict = Dict{String,Int}() # TODO: use generators when 0.4 support is dropped
-    for (i,s) in enumerate(specunique)
-        sdict[s] = i
-    end
+    sdict = Dict{String,Int}(s=>i for (i,s) in enumerate(specunique))
     spec_id = Int[sdict[sn] for sn in spec_name]
 
     return spec_id, spec_name, uniprot_id

--- a/src/types.jl
+++ b/src/types.jl
@@ -38,11 +38,11 @@ type FreqC
     matching::Vector{Int}
     q::Int
     function FreqC(X1::Alignment, X2::Alignment)
-	@extract X1 : N1=N M q
-	@extract X2 : N2=N
-	N = N1 + N2
-	s = q - 1
-	return new(zeros(s * N, s * N), zeros(N * s), [], [0, 0], zeros(M), q)
+        @extract X1 : N1=N M q
+        @extract X2 : N2=N
+        N = N1 + N2
+        s = q - 1
+        return new(zeros(s * N, s * N), zeros(N * s), [], [0, 0], zeros(M), q)
     end
 end
 

--- a/src/types.jl
+++ b/src/types.jl
@@ -14,14 +14,14 @@ immutable Alignment
     uniprot_id::Vector{String}
 end
 
-@compat Base.:(==)(X1::Alignment, X2::Alignment) = all(fn->getfield(X1, fn) == getfield(X2, fn), fieldnames(Alignment))
+Base.:(==)(X1::Alignment, X2::Alignment) = all(fn->getfield(X1, fn) == getfield(X2, fn), fieldnames(Alignment))
 
 immutable HarmonizedAlignments
     X1::Alignment
     X2::Alignment
 end
 
-@compat Base.:(==)(H1::HarmonizedAlignments, H2::HarmonizedAlignments) =
+Base.:(==)(H1::HarmonizedAlignments, H2::HarmonizedAlignments) =
     all(fn->getfield(H1, fn) == getfield(H2, fn), fieldnames(HarmonizedAlignments))
 
 # FreqC is the type of the frequency matrix

--- a/src/utils_fasta.jl
+++ b/src/utils_fasta.jl
@@ -8,13 +8,13 @@ function tally(list)
     tallist = Tuple{eltype(list),Int}[]
 
     for el in slist
-	if el == comp
-	    counter += 1
-	else
-	    push!(tallist, (comp, counter))
-	    comp = el
-	    counter = 1
-	end
+        if el == comp
+            counter += 1
+        else
+            push!(tallist, (comp, counter))
+            comp = el
+            counter = 1
+        end
     end
     push!(tallist, (comp, counter))
     return tallist
@@ -30,15 +30,15 @@ function tally_backref(list)
     tallist = Tuple{eltype(list),Int,Vector{Int}}[]
 
     for (i,el) in zip(p,slist)
-	if el == comp
-	    counter += 1
-	    push!(inds, i)
-	else
-	    push!(tallist, (comp, counter, inds))
-	    comp = el
-	    inds = Int[i]
-	    counter = 1
-	end
+        if el == comp
+            counter += 1
+            push!(inds, i)
+        else
+            push!(tallist, (comp, counter, inds))
+            comp = el
+            inds = Int[i]
+            counter = 1
+        end
     end
     push!(tallist, (comp, counter, inds))
     return tallist
@@ -54,15 +54,15 @@ function index_of_unique(list)
     chgd = true
     prev = list[1]
     for i = 2:L
-	curr = list[i]
-	curr ≥ prev || error("list is not sorted")
-	if curr ≠ prev
-	    chgd && push!(ind, i-1)
-	    chgd = true
-	else
-	    chgd = false
-	end
-	prev = curr
+        curr = list[i]
+        curr ≥ prev || error("list is not sorted")
+        if curr ≠ prev
+            chgd && push!(ind, i-1)
+            chgd = true
+        else
+            chgd = false
+        end
+        prev = curr
     end
     chgd && push!(ind, L)
     return ind

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -3,7 +3,6 @@ module ParalogMatchingTests
 using ParalogMatching
 using FastaIO
 using Base.Test
-using Compat: String
 
 const testfile1 = "X1.fasta.gz"
 const testfile2 = "X2.fasta.gz"


### PR DESCRIPTION
Note that julia 0.6 is currently in beta and is about to become the current stable release.

Also, the default solver functionality was removed
from MathProgInterface, so we use GLPK as default now.